### PR TITLE
[Sikkerhet] Oppretter sikkerhetsfiler description.yaml og catalog-info.yaml og setter security champion i CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 /.security/ @jonasmw94
-/.security/ @jonasmw94
-/.security/ @jonasmw94

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/.security/ @jonasmw94
+/.security/ @jonasmw94
+/.security/ @jonasmw94

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,0 +1,4 @@
+organization: IT
+product: Dataplattform
+repo_types: [Library]
+platforms: []

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "kv-dataplattform-consumer"
+  tags:
+  - "public"
+spec:
+  type: "library"
+  lifecycle: "production"
+  owner: "dataplattform"
+  system: "dataplattformtjenester"


### PR DESCRIPTION
Denne PRen setter security champion i git-repoet ved å legge til `@jonasmw94` i CODEOWNER-filen.
Videre opprettes description-filen under .security-mappen med følgende felter:

- `organization: IT`
- `product: Dataplattform`
- `repo_types: [Library]`
- `platforms: []`

Oppretter også `catalog-info.yaml` hvis den ikke finnes fra før. Dette gjør at repoet kan legges inn inn i utviklerportalen [kartverket.dev](https://kartverket.dev/).

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.