### PR TITLE
TD-1676: Replace deprecated `gradle-build-action` with `setup-gradle`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,11 +15,11 @@ jobs:
           java-version: 17
           distribution: temurin
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+        uses: gradle/wrapper-validation-action@v3
         with:
           working-directory: java
       - name: Publish package
-        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: publish -Pintegration_version=${{github.ref_name}}
           working-directory: java


### PR DESCRIPTION
Issue: https://kartverket.atlassian.net/jira/software/projects/TD/boards/99?selectedIssue=TD-1676